### PR TITLE
add new add_snat_aliases config option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ shorewall_config_options:  # http://shorewall.net/manpages/shorewall.conf.html
   startup_enabled: 'Yes'  # [Yes|No]
   startup_log: '/var/log/shorewall-init.log'  # [pathname]
   verbosity: '2'  # [0=Silent|1=Major|2=All]
+  add_snat_aliases: 'No'
+
 shorewall_interfaces:
   - name: 'eth0'
     zone: 'net'

--- a/templates/etc/shorewall/shorewallv4.conf.j2
+++ b/templates/etc/shorewall/shorewallv4.conf.j2
@@ -116,7 +116,7 @@ ACCOUNTING_TABLE=filter
 
 ADD_IP_ALIASES=No
 
-ADD_SNAT_ALIASES={{ shorewall_config_options.add_snat_aliases }}
+ADD_SNAT_ALIASES={{ shorewall_config_options.add_snat_aliases|default('No') }}
 
 ADMINISABSENTMINDED=Yes
 

--- a/templates/etc/shorewall/shorewallv5.conf.j2
+++ b/templates/etc/shorewall/shorewallv5.conf.j2
@@ -131,7 +131,7 @@ ACCOUNTING_TABLE=filter
 
 ADD_IP_ALIASES=No
 
-ADD_SNAT_ALIASES={{ shorewall_config_options.add_snat_aliases }}
+ADD_SNAT_ALIASES={{ shorewall_config_options.add_snat_aliases|default('No') }}
 
 ADMINISABSENTMINDED=Yes
 


### PR DESCRIPTION
If you define `shorewall_config_options` without this option you will get an error:

```
AnsibleUndefinedVariable: 'dict object' has no attribute 'add_snat_aliases'
```

Also added a default value for backward compatibility because last commit breaks previously working playbooks.