### PR TITLE
add an option to restart shorewall immediately

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ shorewall_rules:
           - '80'
           - '443'
 shorewall_startup: true
+shorewall_immediate_restart: false
 shorewall_zones:
   - name: 'fw'
     in_options:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -93,6 +93,7 @@ shorewall_rules:
           - '80'
           - '443'
 shorewall_startup: true
+shorewall_immediate_restart: false
 shorewall_version: 4
 shorewall_zones:
   - name: 'fw'

--- a/tasks/config_shorewall.yml
+++ b/tasks/config_shorewall.yml
@@ -69,3 +69,6 @@
     mode: 0640
   notify:
     - 'restart shorewall'
+
+- meta: flush_handlers
+  when: shorewall_immediate_restart


### PR DESCRIPTION
This fixes #9 by adding an new option `shorewall_immediate_restart` that will flush handlers after configuration when set to `true`.

Default is `false` to avoid any change in behaviour for existing playbooks.