### PR TITLE
Added CentOS7 as possible OS and added possibility to add comments to rules file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -130,6 +130,7 @@ shorewall_rules:
           - 22
           - 80
           - 443
+        comments: "this rule is for ssh, http and https traffic"
       - source: net
         dest: $FW
         action: ACCEPT

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,8 +2,11 @@
 # tasks file for ansible-shorewall
 - include_tasks: set_facts.yml
 
-- include: debian.yml
+- include_tasks: debian.yml
   when: ansible_os_family == "Debian"
+
+- include_tasks: redhat.yml
+  when: ansible_os_family == "RedHat"
 
 - include: config_shorewall.yml
   when: shorewall_config|bool

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,0 +1,6 @@
+---
+- name: RedHat | Installing Shorewall
+  yum:
+    name: shorewall
+    state: present
+  become: true

--- a/tasks/set_facts.yml
+++ b/tasks/set_facts.yml
@@ -3,32 +3,27 @@
   set_fact:
     shorewall_version: 4
   when: >
-    ansible_distribution == "Debian" and
-    ansible_distribution_version|int < 9
+    ansible_distribution == "Debian" and ansible_distribution_version|int < 9
 
 - name: set_facts | Setting Shorewall Version
   set_fact:
     shorewall_version: 5
   when: >
-    (ansible_distribution == 'Debian' and
-    ansible_distribution_version|int >= 9) or
-    (ansible_distribution == 'Ubuntu' and
-    ansible_distribution_version >= '16.04')
+    (ansible_distribution == 'Debian' and ansible_distribution_version|int >= 9) or
+    (ansible_distribution == 'Ubuntu' and ansible_distribution_version >= '16.04') or
+    (ansible_distribution == 'CentOS' and ansible_distribution_version >= '7.0')
 
 - name: set_facts | Setting Shorewall Default Actions/Macros
   set_fact:
     shorewall_default_actions_macros: legacy
   when: >
-    (ansible_distribution == 'Debian' and
-    ansible_distribution_version|int < 10) or
-    (ansible_distribution == 'Ubuntu' and
-    ansible_distribution_version <= '18.04')
+    (ansible_distribution == 'Debian' and ansible_distribution_version|int < 10) or
+    (ansible_distribution == 'Ubuntu' and ansible_distribution_version < '18.04')
 
 - name: set_facts | Setting Shorewall Default Actions/Macros
   set_fact:
     shorewall_default_actions_macros: new
   when: >
-    (ansible_distribution == 'Debian' and
-    ansible_distribution_version|int > 9) or
-    (ansible_distribution == 'Ubuntu' and
-    ansible_distribution_version > '18.04')
+    (ansible_distribution == 'Debian' and ansible_distribution_version|int > 9) or
+    (ansible_distribution == 'Ubuntu' and ansible_distribution_version >= '18.04') or
+    (ansible_distribution == 'CentOS' and ansible_distribution_version >= '7.0')

--- a/templates/etc/shorewall/rules.j2
+++ b/templates/etc/shorewall/rules.j2
@@ -3,7 +3,8 @@
 ?SECTION {{ item.section }}
 {%   if item.rules is defined %}
 {%     for rule in item.rules %}
-{{ rule.action }}   {{ rule.source }}   {{ rule.dest }}   {{ rule.proto }}   {{ rule.dest_ports|join (',') }}
+{{ rule.action }}   {{ rule.source }}   {{ rule.dest }}   {{ rule.proto }}   {{ rule.dest_ports|join (',') }}    {% if rule.comments is defined %}# {{ rule.comments }} {% endif %}
+
 {%     endfor %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
We like your ansible role for shorewall very much. Unfortunately your role doesn't incorporate CentOS and we have to maintain some CentOS servers as well (beside a lot of Ubuntu servers).
The only difference I could find is the way the shorewall package has to be installed, so I enhanced your role for this.
I also added a comment field to the rules structure, so comments can be added to the entries in the rules file.
I think these enhancements would be beneficial for many people, so that's why I requested this pull request.