### PR TITLE
Added comment and additional fields to rule-template.

### DIFF
--- a/templates/etc/shorewall/rules.j2
+++ b/templates/etc/shorewall/rules.j2
@@ -1,9 +1,13 @@
 {{ ansible_managed | comment }}
+#ACTION     SOURCE          DEST        PROTO       DPORT        SPORT     ORIGDEST   RATE      USER      MARK    CONNLIMIT     TIME     HEADERS    SWITCH
 {% for item in shorewall_rules %}
 ?SECTION {{ item.section }}
 {%   if item.rules is defined %}
 {%     for rule in item.rules %}
-{{ rule.action }}   {{ rule.source }}   {{ rule.dest }}   {{ rule.proto }}   {{ rule.dest_ports|join (',') }}
+{% if (rule.comment is defined) and (rule.comment|length) %}
+#{{ rule.comment }}
+{% endif %}
+{{ rule.action }}   {{ rule.source }}   {{ rule.dest }}   {{ rule.proto|default ("-") }}   {{ rule.dest_ports|default ("-")|join (',') }}   {{ rule.source_ports|default ("-")|join (',') }}   {{ rule.origdest|default ("-") }}   {{ rule.rate|default ("-") }}   {{ rule.user|default ("-") }}   {{ rule.mark|default ("-") }}   {{ rule.connlimit|default ("-") }}   {{ rule.time|default ("-") }}   {{ rule.headers|default ("-") }}   {{ rule.switch|default ("-") }}
 {%     endfor %}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
As discussed in https://github.com/mrlesmithjr/ansible-shorewall/issues/19 I've extended the `rules.j2` template file:
1. The field **rules.comment** puts a comment-line (prefixed with **#**) above each rule. The field is treated optional: If it is not set or empty, there would be no difference in the resulting file compared to the previous rules template file.
2. A header line including all field names is included as a comment on top of the file (right under the **ansible_managed** comment). This makes it much easier to read complex rules with many fields set.
3. All supported fields based on the **shorewall-rules** man page are added to the rule line:
- source_ports
- origdest
- rate
- user
- mark
- connlimit
- time
- headers
- switch
All additional fields (and the field **dest_ports** for that matter) are treated as optional. Since the fields in the rule line are separated by spaces and the position of the parameters does matter, all unset parameters are set to **-** as a default corresponding with the shorewall docs.

The fact that **dest_ports** is now optional makes it possible to use **shorewall macros** which makes the rules much easier to read.
For example:
```
rules:
  - source: 'net'
    dest: '$FW'
    action: 'SSH(ACCEPT)'
    comment: "Example rule with macro for SSH"
```
would expand to
```
#Example rule with macro for SSH
SSH(ACCEPT)   net   $FW   -   -   -   -   -   -   -   -   -   -   -
```